### PR TITLE
Remove Vyshnav, restore Sharang as active team member

### DIFF
--- a/functions/mcp.js
+++ b/functions/mcp.js
@@ -21,7 +21,7 @@ const INSTRUCTIONS = `PK Work is the task management system for Public Knowledge
 
 Tool choice: use pkwork_status for any "what's pending / what's going on" question (scope = client name, person first-name, or "today"; omit for studio-wide) and show actual task lists, not just counts. Use pkwork_search first whenever something is referenced by name and you need its id. Use pkwork_task_add / pkwork_task_set for changes. pkwork_raw is the escape hatch for anything else, including leaves.
 
-Team emails (for assignee and leaves fields): gyan@, charu@, anandu@, mohit@, rakesh@, ananya@, vyshnav@ — all @publicknowledge.co. Sharang (sharang@) is on leave ~June–July 2026.
+Team emails (for assignee and leaves fields): gyan@, charu@, sharang@, anandu@, mohit@, rakesh@, ananya@ — all @publicknowledge.co.
 
 Conventions:
 - Statuses: backlog, todo, in_progress, review, done. Priorities: low, medium, high, urgent. Deadlines are ISO dates (2026-06-20).

--- a/src/config.js
+++ b/src/config.js
@@ -30,15 +30,13 @@ export const googleOAuthClientId = ''
 export const TEAM = [
   { email: 'gyan@publicknowledge.co', name: 'Gyan', color: '#4f46e5', role: 'admin' },
   { email: 'charu@publicknowledge.co', name: 'Charu', color: '#0891b2', role: 'admin' },
-  // On leave ~1 month (from June 2026) — restore when back
-  // { email: 'sharang@publicknowledge.co', name: 'Sharang', color: '#c026d3', role: 'member' },
+  { email: 'sharang@publicknowledge.co', name: 'Sharang', color: '#c026d3', role: 'member' },
   { email: 'anandu@publicknowledge.co', name: 'Anandu', color: '#ea580c', role: 'member' },
   { email: 'mohit@publicknowledge.co', name: 'Mohit', color: '#059669', role: 'member' },
   { email: 'rakesh@publicknowledge.co', name: 'Rakesh', color: '#d97706', role: 'member' },
   // Only on one project and doesn't use this tool — restore if that changes
   // { email: 'saurabh@publicknowledge.co', name: 'Saurabh', color: '#db2777', role: 'member' },
   { email: 'ananya@publicknowledge.co', name: 'Ananya', color: '#65a30d', role: 'member' },
-  { email: 'vyshnav@publicknowledge.co', name: 'Vyshnav', color: '#7c3aed', role: 'member' },
 ]
 
 // Task statuses and their display config


### PR DESCRIPTION
## Summary

Updates the team roster: Vyshnav is removed and Sharang (back from leave) is restored as an active member.

## Changes

- **`src/config.js`** — Uncommented Sharang in the frontend `TEAM` list (dropping the "on leave" note) and removed the Vyshnav entry.
- **`functions/mcp.js`** — Updated the assignee/leaves prompt to list `sharang@` as an active team email and removed `vyshnav@` plus the "Sharang is on leave" note.

No changes were needed in `functions/index.js` (`TEAM_MEMBERS`) or `functions/slack.js` — both already listed Sharang and never included Vyshnav. Historical `docs/plans/` references were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LrrWE49WAfMMYCpJqRXcar)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated team membership used across the app so attendance and role-based views reflect the latest roster.
  * Restored the correct inclusion of current team members and removed an outdated entry.
  * Cleaned up team contact guidance to match the latest availability information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->